### PR TITLE
Add support for tarsnap options when backing up

### DIFF
--- a/acts
+++ b/acts
@@ -4,6 +4,9 @@
 set -u
 # Exit if a pipeline exits non-zero
 set -e
+# While making changes to the script, set -x
+# comment out for normal use
+#set -x
 
 starttime=$(date +%s)
 
@@ -42,6 +45,7 @@ backuptargets="${backuptargets=}"
 prebackupscript="${prebackupscript=}"
 postbackupscript="${postbackupscript=}"
 tarsnap="${tarsnap:=tarsnap}"
+tarsnapbackupoptions="${tarsnapbackupoptions=}"
 lockfile="${lockfile=/var/run/acts}"
 LANG="${LANG=en_US.UTF-8}" ; export LANG
 
@@ -116,7 +120,7 @@ backuprc=0 # Notice any failed backups
 for dir in $backuptargets ; do
     log_verbose "Backing up $dir..."
     nicedirname=$(echo "$dir" | tr -d '/')
-    if ! output="$($tarsnap -c -f "$hostname-$archivetype-$today-$nicedirname" -C / "$dir" 2>&1)" ; then
+    if ! output="$($tarsnap -c -f "$hostname-$archivetype-$today-$nicedirname" -C / $tarsnapbackupoptions "$dir" 2>&1)" ; then
         log_message "Failed to back up \"$dir\"! ($output)"
         backuprc=1
     fi

--- a/acts.conf
+++ b/acts.conf
@@ -11,6 +11,12 @@ backuptargets="var etc home root"
 # Default: tarsnap
 tarsnap="nice -n19 ionice -c3 tarsnap"
 
+# tarsnapbackupoptions
+# What options to use when backing up.
+# e.g.: --one-file-system --humanize-numbers -X /etc/acts.exclude
+# Default: unset
+tarsnapbackupoptions="--one-file-system --humanize-numbers -X /etc/acts.exclude"
+
 # verbose
 # -1 silent. 0=normal. 1=verbose. 2=debug.
 # Default: 0

--- a/acts.exclude
+++ b/acts.exclude
@@ -1,0 +1,11 @@
+*/.AppleDouble
+*/cache/*
+*/.cache/*
+*/Cache/*
+*nobackup/*
+*/.Trash/*
+*/Temporary\ Items/*
+*/tmp/*
+*/Trash/*
+*/.gvfs
+home/someuser/work/git/*


### PR DESCRIPTION
e.g. --one-file-system and/or -X /etc/acts.exclude
add an example to acts.conf
include a sample acts.exclude