### PR TITLE
Fixing quoting issue with UTC argument

### DIFF
--- a/acts
+++ b/acts
@@ -126,7 +126,7 @@ archives=$(echo "$archives_unsorted" | sort -n)
 
 # When is now?
 # Instead of re-running date, be paranoid the day was microseconds away from ending
-today=$(date "$utc" "+%Y-%m-%d_%H:%M:%S")
+today=$(date $utc "+%Y-%m-%d_%H:%M:%S")
 year=$(echo "$today" | cut -d_ -f1 | cut -d- -f1)
 month=$(echo "$today" | cut -d_ -f1 | cut -d- -f2)
 # day=$(echo "$today" | cut -d_ -f1 | cut -d- -f3) # unused


### PR DESCRIPTION
When `uselocaltime` is set, `$utc` is assigned an empty string. When quoted, this empty string creates an empty string in the `date` argument vector. When unquoted, this empty string is eaten by the shell and not passed to `date`.

```
date: extra operand ‘+%Y-%m-%d_%H:%M:%S’
Try 'date --help' for more information.
Exiting unexpectedly.

% date +%Y-%m-%d_%H:%M:%S
2017-05-01_10:44:12
% date ""  +%Y-%m-%d_%H:%M:%S
date: extra operand ‘+%Y-%m-%d_%H:%M:%S’
Try 'date --help' for more information.
```