### PR TITLE
Custom backup delimiter

### DIFF
--- a/acts
+++ b/acts
@@ -80,6 +80,7 @@ fi
 verbose="${verbose=0}"
 hostname="${hostname=$(hostname -s)}"
 uselocaltime="${uselocaltime=0}"
+delimiter="${delimiter=" "}"
 backuptargets="${backuptargets=}"
 prebackupscript="${prebackupscript=}"
 postbackupscript="${postbackupscript=}"
@@ -158,6 +159,7 @@ fi
 
 # PART 3: Backup
 backuprc=0 # Notice any failed backups
+IFS="$delimiter"
 for dir in $backuptargets; do
     archive_starttime=$(date +%s)
     nicedirname=$(echo "$dir" | tr -d '/')
@@ -226,6 +228,7 @@ trap - INT TERM EXIT
 rm -f "$lockfile/pid"
 rmdir "$lockfile"
 
+unset IFS
 endtime=$(date +%s)
 log_verbose "acts-finished duration=$((endtime - starttime))s action=exiting"
 exit 0

--- a/acts.conf.sample
+++ b/acts.conf.sample
@@ -2,9 +2,12 @@
 # acts configuration file
 
 # Directory list delimiter 
-# Specify delimiter=":" (or any desired special character) if there
-# are spaces in a directory name 
-# Default: space
+# Do not set this variable unless there are spaces in the path name of any
+# directory which you wish to backup.
+# If necessary, specify delimiter=":" (or any desired special character that
+# is not in the allowed set of characters for directory/file names for the
+# operating system being used.) 
+# Default: space 
 # delimiter=":"
 
 # backuptargets

--- a/acts.conf.sample
+++ b/acts.conf.sample
@@ -1,8 +1,15 @@
 #!/bin/sh
 # acts configuration file
 
+# Directory list delimiter 
+# Specify delimiter=":" (or any desired special character) if there
+# are spaces in a directory name 
+# Default: space
+# delimiter=":"
+
 # backuptargets
-# Space-separated list of directories to backup, relative to /. This is a required option.
+# Space-separated (or other delimiter-separted) list of directories to
+# backup, relative to /. This is a required option.
 # Default: unset
 backuptargets="var etc home root"
 

--- a/acts.conf.sample
+++ b/acts.conf.sample
@@ -1,13 +1,13 @@
 #!/bin/sh
 # acts configuration file
 
-# Directory list delimiter 
+# Directory list delimiter
 # Do not set this variable unless there are spaces in the path name of any
 # directory which you wish to backup.
 # If necessary, specify delimiter=":" (or any desired special character that
 # is not in the allowed set of characters for directory/file names for the
-# operating system being used.) 
-# Default: space 
+# operating system being used.)
+# Default: space
 # delimiter=":"
 
 # backuptargets


### PR DESCRIPTION
Allow directory names with embedded spaces to be listed in the list of directories to be backed up. This is accomplished by allowing a delimiter other than a blank space.

